### PR TITLE
Revise theme toggle with inline SVG and style adjustments

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,8 +13,12 @@
 <body>
   <!-- theme toggle -->
   <button class="theme-toggle" aria-label="Toggle dark mode">
-    <img class="icon-sun"  src="assets/sun.svg"  alt="">
-    <img class="icon-moon" src="assets/moon.svg" alt="">
+    <!-- filled circle for light mode -->
+    <svg class="icon-dot"   viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="12"/></svg>
+    <!-- crescent for dark mode -->
+    <svg class="icon-moon"  viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M21 12.79A9 9 0 0 1 12.21 3a7 7 0 1 0 8.79 9.79Z"/>
+    </svg>
   </button>
 
   <main class="container">

--- a/script.js
+++ b/script.js
@@ -21,7 +21,7 @@ if(!matchMedia("(prefers-reduced-motion:reduce)").matches){
 
 /* ---------- staggered entry ---------- */
 window.addEventListener("load",() => {
-  requestAnimationFrame(() => document.body.classList.add("is-loaded"));
+  setTimeout(() => document.body.classList.add("is-loaded"), 80); // slight pause
 });
 
 /* ---------- theme toggle ---------- */

--- a/styles.css
+++ b/styles.css
@@ -3,10 +3,10 @@
   --ink-100:#1c2431;
   --ink-70:#525c6a;
   --ink-40:#8d99ae;
-  --paper:#f3f3f5;          /* Maddie\u2019s soft grey */
-  --paper-dark:#26252b;
+  --paper:#e7e7e7;        /* lighter – matches Maddie light */
+  --paper-dark:#1f1e23;   /* slightly deeper charcoal */
   --ink-dark:#e5e7ea;
-  --duration:.6s;
+  --duration:.65s;         /* slower for the softer entry */
 }
 
 /* ---------- dark mode ---------- */
@@ -28,7 +28,7 @@ body{
   transition:background-color .3s, color .3s;
 }
 a{color:inherit;text-decoration:underline;text-decoration-thickness:1px}
-.container{max-width:680px;margin:0 auto}
+.container{max-width:680px;margin:110px auto 0;    /* 110 px = Maddie safe-zone on mobile */}
 
 /* ---------- typography ---------- */
 .hero{font-size:clamp(2.8rem,6vw,4.5rem);font-weight:900;margin-bottom:1rem}
@@ -57,15 +57,16 @@ html[data-theme="dark"] .icon{filter:invert(1)}
   transition:background .3s;
 }
 .theme-toggle img{width:24px;height:24px;pointer-events:none;transition:opacity .3s;}
-.icon-moon{opacity:0} /* shown in dark mode */
+.icon-dot {fill:var(--ink-100);}
+.icon-moon{fill:#fff;opacity:0}          /* white moon on dark */
 html[data-theme="dark"] .icon-moon{opacity:1}
-html[data-theme="dark"] .icon-sun {opacity:0}
+html[data-theme="dark"] .icon-dot {opacity:0}
 
 /* ---------- entry animation ---------- */
 .fade{
-  opacity:0;transform:translateY(16px);
-  transition:opacity var(--duration) cubic-bezier(.4,0,.2,1),
-             transform var(--duration) cubic-bezier(.4,0,.2,1);
+  opacity:0;transform:translateY(20px);
+  transition:opacity var(--duration) cubic-bezier(.22,.61,.36,1),
+             transform var(--duration) cubic-bezier(.22,.61,.36,1);
   transition-delay:var(--d);
 }
 body.is-loaded .fade{opacity:1;transform:none}


### PR DESCRIPTION
## Summary
- inline SVG theme toggle icons
- adjust background colors to match Maddie's grays
- add top breathing zone above the headline
- tweak fade-in timing and easing
- delay staggered entry slightly for smoother feel

## Testing
- `git status --short`