### PR TITLE
feat: single-screen résumé page (Maddie.ai parity)

### DIFF
--- a/assets/crescent.svg
+++ b/assets/crescent.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="#ffffff">
-  <path d="M21 12.8A9 9 0 0 1 12.2 3a7 7 0 1 0 8.8 9.8z"/>
+<svg viewBox="0 0 24 24" width="24" height="24" fill="#ffffff" xmlns="http://www.w3.org/2000/svg">
+  <path d="M21 12.79A9 9 0 0 1 12.21 3a7 7 0 1 0 8.79 9.79Z"/>
 </svg>

--- a/assets/dot.svg
+++ b/assets/dot.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="#2b292f">
-  <circle cx="12" cy="12" r="12" />
+<svg viewBox="0 0 24 24" width="24" height="24" fill="#2b292f" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="12" r="12"/>
 </svg>

--- a/index.html
+++ b/index.html
@@ -1,38 +1,36 @@
 <!doctype html>
 <html lang="en" data-theme="light">
 <head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <meta name="color-scheme" content="light dark"/>
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="styles.css"/>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+
+  <!-- Inter 400 / 500 / 600 -->
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
+
+  <link rel="stylesheet" href="styles.css" />
   <title>Jiovan Melendez</title>
 </head>
 
 <body>
-  <!-- light / dark toggle (touch-target 44 px) -->
+  <!-- light / dark toggle -->
   <button class="theme-toggle" aria-label="Toggle dark mode">
-    <img src="assets/dot.svg"      class="dot"      alt="" draggable="false">
-    <img src="assets/crescent.svg" class="crescent" alt="" draggable="false">
+    <img class="dot"      src="assets/dot.svg"      alt="" draggable="false">
+    <img class="crescent" src="assets/crescent.svg" alt="" draggable="false">
   </button>
 
-  <!-- entire résumé fits inside this flex card (no scroll) -->
+  <!-- one-column résumé -->
   <main class="card is-loading">
     <h1 class="hero">Hi, I'm Jiovan.</h1>
 
-    <p class="alias">
-      Siri calls me “Jee oh van” (close enough).
+    <p class="intro">
+      Some people call me Jiovan. I’ve been building AI at
+      <a href="https://podium.com" target="_blank" rel="noopener">Podium</a>
+      for the last <span id="counter" aria-live="off"></span> - and Siri still can’t pronounce my name.
     </p>
 
     <p class="bio">
-      I build AI products.
-    </p>
-
-    <p class="tenure">
-      I’ve been building AI at
-      <a href="https://podium.com" target="_blank" rel="noopener">Podium</a>
-      for the last <span id="counter" aria-live="off"></span>.
+      I live in Utah by way of San Francisco, a quick stint in New York, then back to the Bay Area - half Puerto Rican, half Cuban.
     </p>
 
     <section class="previously">
@@ -41,17 +39,26 @@
       <dl>
         <div class="row">
           <dt class="company">YC</dt>
-          <dd class="role">Product Consultant <span class="years">2017 - 18</span></dd>
+          <dd class="role">
+            Product Consultant · SF
+            <span class="years">2017-18</span>
+          </dd>
         </div>
 
         <div class="row">
           <dt class="company">Vivint Solar</dt>
-          <dd class="role">Product Lead <span class="years">2014 - 17</span></dd>
+          <dd class="role">
+            Product Lead · SLC / NYC / SF
+            <span class="years">2014-17</span>
+          </dd>
         </div>
 
         <div class="row">
           <dt class="company">Scan → Snap</dt>
-          <dd class="role">PM (early) <span class="years">2013 - 14</span></dd>
+          <dd class="role">
+            PM&nbsp;(early) · SF
+            <span class="years">2013-14</span>
+          </dd>
         </div>
       </dl>
     </section>

--- a/script.js
+++ b/script.js
@@ -1,33 +1,29 @@
-/* start date of Podium tenure */
-const START = new Date("2018-10-01T15:00:00-06:00").getTime();
-const span  = document.getElementById("counter");
+/* ---------- live tenure counter ---------------------------------- */
+const START = new Date("2018-10-01T15:00:00-06:00").getTime(); // adjust if needed
+const out   = document.getElementById("counter");
 
-function pad(n){return `${n}`.padStart(2,"0");}
-
-function render(){
-  const ms   = Date.now() - START;
-  const days = Math.floor(ms / 86_400_000);
-  const hrs  = Math.floor(ms / 3_600_000) % 24;
-  const mins = Math.floor(ms /   60_000) % 60;
-  const secs = Math.floor(ms /    1_000) % 60;
-  span.textContent =
-    `${days} days, ${pad(hrs)} hours, ${pad(mins)} minutes, and ${pad(secs)} seconds`;
-  requestAnimationFrame(render);
+const pad = n => n.toString().padStart(2,"0");
+function tick(){
+  const ms = Date.now() - START;
+  const d  = Math.floor(ms / 86_400_000);
+  const h  = Math.floor(ms /   3_600_000) % 24;
+  const m  = Math.floor(ms /      60_000) % 60;
+  const s  = Math.floor(ms /       1_000) % 60;
+  out.textContent =
+    `${d} days, ${pad(h)} hours, ${pad(m)} minutes, and ${pad(s)} seconds`;
+  requestAnimationFrame(tick);
 }
-requestAnimationFrame(render);
+requestAnimationFrame(tick);
 
-/* reveal card after assets load */
-window.addEventListener("load",()=>requestAnimationFrame(()=>{
+/* ---------- reveal after load ------------------------------------ */
+addEventListener("load",()=>requestAnimationFrame(()=>{
   document.querySelector(".card").classList.remove("is-loading");
 }));
 
-/* light / dark toggle (persists) */
-const root=document.documentElement;
-const btn =document.querySelector(".theme-toggle");
-const KEY ="theme";
+/* ---------- theme toggle ----------------------------------------- */
+const root=document.documentElement, btn=document.querySelector(".theme-toggle"), KEY="theme";
 root.setAttribute("data-theme",localStorage.getItem(KEY)||"light");
 btn.addEventListener("click",()=>{
   const next=root.getAttribute("data-theme")==="light"?"dark":"light";
-  root.setAttribute("data-theme",next);
-  localStorage.setItem(KEY,next);
+  root.setAttribute("data-theme",next);localStorage.setItem(KEY,next);
 });

--- a/styles.css
+++ b/styles.css
@@ -1,96 +1,61 @@
-/* ─────  TOKENS  ───── */
+/* 1. Tokens & reset ----------------------------------------------- */
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
 :root{
-  /* light palette */
-  --paper:#f3f3f5;              /* Maddie bg (L95) */
-  --ink:#575b66;                /* body text (L46) */
-  --ink-fade:#8f939c;           /* secondary */
-  --rule:#dcdcdf;               /* hairline separator */
-
-  /* dark palette */
-  --paper-dark:#252428;         /* bg (L12) */
-  --ink-dark:#e6e7ea;           /* text (L90) */
-  --ink-fade-dark:#888b92;      /* secondary dark */
-  --rule-dark:#3d3d3f;          /* hairline dark */
-
-  --ease: cubic-bezier(.33,0,.2,1);   /* Maddie fade curve */
-  --radius:0;                          /* all square */
+  --paper:#f3f3f5; --ink:#575b66; --ink-fade:#8f939c; --rule:#dcdcdf;
+  --paper-dark:#252428; --ink-dark:#e6e7ea; --ink-fade-dark:#888b92; --rule-dark:#3d3d3f;
+  --ease:cubic-bezier(.33,0,.2,1);
 }
-
-html[data-theme=dark]{
-  --paper:var(--paper-dark);
-  --ink:var(--ink-dark);
-  --ink-fade:var(--ink-fade-dark);
-  --rule:var(--rule-dark);
-}
-
-/* ─────  RESET  ───── */
+html[data-theme=dark]{--paper:var(--paper-dark);--ink:var(--ink-dark);
+                      --ink-fade:var(--ink-fade-dark);--rule:var(--rule-dark);}
 *{box-sizing:border-box;margin:0;padding:0}
-::selection{background:#c1c3c8;color:#fff}
 body{
   font-family:"Inter",system-ui,sans-serif;
-  background:var(--paper);
-  color:var(--ink);
-  line-height:1.6;
-  -webkit-font-smoothing:antialiased;
+  background:var(--paper);color:var(--ink);
+  line-height:1.6;-webkit-font-smoothing:antialiased;
   transition:background .35s var(--ease),color .35s var(--ease);
 }
+a{color:inherit;text-decoration:underline;text-decoration-thickness:1px}
 
-/* ─────  CARD LAYOUT (one-screen)  ───── */
+/* 2. Card layout --------------------------------------------------- */
 .card{
-  position:relative;
   height:calc(100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom));
-  max-width:680px;
-  margin:0 auto;
-  padding:
-    calc(env(safe-area-inset-top) + 140px) /* top gap matches Maddie whitespace */
-    24px
-    calc(env(safe-area-inset-bottom) + 32px);
-  display:flex;
-  flex-direction:column;
-  gap:24px;
+  max-width:680px;margin:0 auto;
+  padding:calc(env(safe-area-inset-top)+140px) 24px calc(env(safe-area-inset-bottom)+32px);
+  display:flex;flex-direction:column;gap:24px;
   opacity:0;transform:translateY(24px);
   transition:opacity .6s var(--ease),transform .6s var(--ease);
 }
 .card:not(.is-loading){opacity:1;transform:none}
 
-/* ─────  TYPOGRAPHY  ───── */
-.hero   {font-size:clamp(1.7rem,6vw,2.1rem);font-weight:600}
-.alias  {font-size:1rem}
-.bio    {font-size:1.125rem;font-weight:500}
-.tenure {font-size:1rem;font-weight:500}
-a       {color:inherit;text-decoration:underline;text-decoration-thickness:1px}
+/* 3. Type scale ---------------------------------------------------- */
+.hero{font-size:clamp(1.7rem,6vw,2.1rem);font-weight:600}
+.intro{font-size:1rem}
+.bio{font-size:1.125rem;font-weight:500}
+.tenure{font-size:1rem;font-weight:500}
 
-/* ─────  PREVIOUSLY  ───── */
-.section-title{
-  font-size:.75rem;
-  letter-spacing:.14em;
-  color:var(--ink-fade);
-  font-weight:600;
-}
+/* 4. Timeline ------------------------------------------------------ */
+.section-title{font-size:.75rem;letter-spacing:.14em;font-weight:600;color:var(--ink-fade)}
 dl{display:flex;flex-direction:column;gap:8px}
 .row{
-  display:flex;justify-content:space-between;align-items:flex-start;
-  padding:6px 0;border-bottom:1px solid var(--rule);
+  display:flex;justify-content:space-between;gap:8px;
+  padding:6px 16px;border-bottom:1px solid var(--rule);
 }
 .company{font-weight:600}
-.role   {font-weight:500}
-.years  {font-weight:400;color:var(--ink-fade);margin-left:8px}
-@media(max-width:360px){.row{flex-direction:column;gap:0}}
+.role{font-weight:500}
+.years{font-weight:400;color:var(--ink-fade)}
+@media(max-width:360px){.row{flex-direction:column}}
 
+/* 5. Theme toggle -------------------------------------------------- */
 .theme-toggle{
-  position:fixed;
-  top:calc(env(safe-area-inset-top) + 16px);
-  right:16px;
+  position:fixed;top:calc(env(safe-area-inset-top)+16px);right:16px;
   width:44px;height:44px;border:none;background:none;cursor:pointer;
 }
 .theme-toggle img{
-  width:24px;height:24px;pointer-events:none;transition:opacity .3s;
+  width:24px;height:24px;pointer-events:none;transition:opacity .3s var(--ease);
 }
 .crescent{opacity:0}
 html[data-theme=dark] .crescent{opacity:1}
-html[data-theme=dark] .dot     {opacity:0}
+html[data-theme=dark] .dot{opacity:0}
 
-/* ─────  MOTION PREFERENCE  ───── */
-@media(prefers-reduced-motion:reduce){
-  .card{transition:none}
-}
+/* 6. Reduce-motion guard ------------------------------------------ */
+@media(prefers-reduced-motion:reduce){.card{transition:none}}


### PR DESCRIPTION
## What & why
- rebuild site as a one-column résumé inspired by Maddie.ai
- add live tenure counter and theme toggle
- update timeline with locations and year ranges

## Manual test checklist
- [x] `grep -n "[—–]" -r .` returns nothing
